### PR TITLE
fix(typo): Changed the starter button text

### DIFF
--- a/components/ui/background-paths.tsx
+++ b/components/ui/background-paths.tsx
@@ -116,7 +116,7 @@ export function BackgroundPaths({ title = 'Background Paths', onStart, children 
                             group-hover:-translate-y-0.5 border border-black/10 dark:border-white/10
                             hover:shadow-md dark:hover:shadow-neutral-800/50"
 						>
-							<span className="opacity-90 group-hover:opacity-100 transition-opacity">Hızlı Bşlangıç</span>
+							<span className="opacity-90 group-hover:opacity-100 transition-opacity">Hızlı Başlangıç</span>
 							<span
 								className="ml-2 opacity-70 group-hover:opacity-100 group-hover:translate-x-1.5 
                                 transition-all duration-300"


### PR DESCRIPTION
The button content displayed on the start screen contained a typo, I fixed this.

Screenshots:

![image](https://github.com/user-attachments/assets/783d5e53-12be-4fd8-9db1-a03934580dea)
![image](https://github.com/user-attachments/assets/40e3f22e-c38a-4fbb-abd2-5b98a35a817a)
